### PR TITLE
[13] Handle empty response on search library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ wrapper {
 }
 
 group = 'org.platops.gradle.plugins.qt'
-version = '1.0.2-SNAPSHOT'
+version = '1.0.2'
 description = 'Gradle QT plugin for framework specific tasks integration'
 
 String vcsBaseUrl = "https://github.com/axmetishe"

--- a/src/main/groovy/org/platops/gradle/plugins/qt/QTPlugin.groovy
+++ b/src/main/groovy/org/platops/gradle/plugins/qt/QTPlugin.groovy
@@ -153,6 +153,7 @@ class QTPlugin implements Plugin<Project> {
               targetPlatform = binaryTargetPlatform.operatingSystem.toFamilyName()
               binaryFile = cppBinary.getExecutableFile().get().getAsFile()
               buildVariant = cppBinary.isOptimized() ? 'release' : 'debug'
+              useDebugLibraries = cppBinary.isOptimized() ? false : !qtToolchain.brew
               installPath = cppBinary.getInstallDirectory().dir('lib').get()
             }
 

--- a/src/main/groovy/org/platops/gradle/plugins/qt/internal/tasks/QTBundleTask.groovy
+++ b/src/main/groovy/org/platops/gradle/plugins/qt/internal/tasks/QTBundleTask.groovy
@@ -55,6 +55,9 @@ class QTBundleTask extends DefaultTask {
   public String buildVariant
 
   @Input
+  public Boolean useDebugLibraries
+
+  @Input
   public String installPath
 
   @Input
@@ -80,6 +83,14 @@ class QTBundleTask extends DefaultTask {
 
   void setBuildVariant(String buildVariant) {
     this.buildVariant = buildVariant
+  }
+
+  Boolean getUseDebugLibraries() {
+    return useDebugLibraries
+  }
+
+  void setUseDebugLibraries(Boolean useDebugLibraries) {
+    this.useDebugLibraries = useDebugLibraries
   }
 
   String getInstallPath() {
@@ -181,7 +192,7 @@ class QTBundleTask extends DefaultTask {
         deployArgs.add("-libpath=${installPath}")
         deployArgs.add('-always-overwrite')
         deployArgs.add('-verbose=1')
-        buildVariant == 'debug' ? deployArgs.add('-use-debug-libs') : null
+        buildVariant == 'debug' ? (useDebugLibraries ? deployArgs.add('-use-debug-libs') : null) : null
         break
     }
     deployArgs.addAll(extension.deployParameters[targetPlatform])

--- a/src/main/groovy/org/platops/gradle/plugins/qt/internal/toolchains/QTToolchainOSX.groovy
+++ b/src/main/groovy/org/platops/gradle/plugins/qt/internal/toolchains/QTToolchainOSX.groovy
@@ -78,11 +78,23 @@ class QTToolchainOSX extends QTToolchain {
           LOGGER.info("Adding '${library.name}' as library.")
           librariesList.add(library)
         } else {
-          LOGGER.warn("""
-            Unable to find binary for '${libraryName}' library from '${module}' module.
-            Please check your SDK installation.
-          """)
+          LOGGER.warn("Warning: Unable to find binary for '${libraryName}' library from '${module}' module.")
+          if (debuggable) {
+            libraryName = module
+            availableLibraries = findFiles(moduleLibrary, libraryName)
+
+            // We will try to use Release library variant the same way as with Homebrew installation
+            if (availableLibraries) {
+              LOGGER.warn("Warning: Adding '${libraryName}' library instead.")
+              File library = availableLibraries.sort().first()
+              LOGGER.info("Adding '${library.name}' as library.")
+              this.brew = true
+              librariesList.add(library)
+            }
+          }
         }
+      } else {
+        LOGGER.warn("Couldn't find '${module}' framework directory")
       }
     }
 

--- a/src/main/groovy/org/platops/gradle/plugins/qt/internal/toolchains/QTToolchainOSX.groovy
+++ b/src/main/groovy/org/platops/gradle/plugins/qt/internal/toolchains/QTToolchainOSX.groovy
@@ -72,9 +72,17 @@ class QTToolchainOSX extends QTToolchain {
           LOGGER.info("Homebrew QT - linkage over Release variant of '${module}'")
           libraryName = module
         }
-        File library = findFiles(moduleLibrary, libraryName).sort().first()
-        LOGGER.info("Adding '${library.name}' as library.")
-        librariesList.add(library)
+        List<File> availableLibraries = findFiles(moduleLibrary, libraryName)
+        if (availableLibraries) {
+          File library = availableLibraries.sort().first()
+          LOGGER.info("Adding '${library.name}' as library.")
+          librariesList.add(library)
+        } else {
+          LOGGER.warn("""
+            Unable to find binary for '${libraryName}' library from '${module}' module.
+            Please check your SDK installation.
+          """)
+        }
       }
     }
 


### PR DESCRIPTION
- Handle empty response on search library
- Add attempt to use release libraries variant in case debug variant is not available on MacOS platform

Tested on:
```
Hardware:
    Hardware Overview:

      Model Name: MacBook Pro
      Model Identifier: MacBookPro16,1
      Processor Name: 6-Core Intel Core i7
      Processor Speed: 2.6 GHz
      Number of Processors: 1
      Total Number of Cores: 6
      L2 Cache (per Core): 256 KB
      L3 Cache: 12 MB
      Hyper-Threading Technology: Enabled
      Memory: 32 GB
      System Firmware Version: 1554.140.20.0.0 (iBridge: 18.16.14759.0.1,0)

Software:
    System Software Overview:

      System Version: macOS 11.6 (20G165)
      Kernel Version: Darwin 20.6.0
```

- openjdk 11.0.11 2021-04-20
- aqtinstall(aqt) v1.2.5 on Python 3.9.7 [CPython Clang 12.0.5 (clang-1205.0.22.9)]
- QT 5.15.2
